### PR TITLE
Switch ManageRooms to Supabase data

### DIFF
--- a/src/lib/supabase.tsx
+++ b/src/lib/supabase.tsx
@@ -1,7 +1,31 @@
-// src/lib/supabase.ts
 import { createClient } from "@supabase/supabase-js";
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL!;
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY!;
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+
+export interface Room {
+  id: string;
+  hostel_id: string;
+  name: string;
+  type: string;
+  capacity: number;
+  price: number;
+  availability: number;
+  amenities: string[];
+  images: string[];
+}
+
+export const fetchRooms = (hostelId: string) =>
+  supabase.from("rooms").select("*").eq("hostel_id", hostelId);
+
+export const createRoom = (room: Omit<Room, "id">) =>
+  supabase.from("rooms").insert([room]).select().single();
+
+export const updateRoom = (id: string, updates: Partial<Room>) =>
+  supabase.from("rooms").update(updates).eq("id", id).select().single();
+
+export const deleteRoomById = (id: string) =>
+  supabase.from("rooms").delete().eq("id", id);
+


### PR DESCRIPTION
## Summary
- add CRUD helpers for the rooms table
- fetch rooms from Supabase in ManageRooms
- use Supabase insert/update/delete instead of mock data

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68400ae05d74832a8108ffc8a612f1ac