### PR TITLE
Remove leftover comment

### DIFF
--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -92,7 +92,7 @@ const Register = () => {
             <option value="hosteller">Hosteller</option>
             <option value="owner">Owner</option>
             <option value="agent">Agent</option>
-            <option value="admin">Admin</option> {/* ✅ Add this line */}
+            <option value="admin">Admin</option>
 
           </select>
         </CardContent>


### PR DESCRIPTION
## Summary
- cleaned up markup in the registration page by removing a stray comment

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683ff0e63d00832a98adaf66843060c3