### PR TITLE
Fix toast cleanup

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -6,7 +6,7 @@ import type {
 } from "@/components/ui/toast"
 
 const TOAST_LIMIT = 1
-const TOAST_REMOVE_DELAY = 1000000
+const TOAST_REMOVE_DELAY = 10000
 
 type ToasterToast = ToastProps & {
   id: string
@@ -179,7 +179,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- adjust toast remove delay to a sensible value
- ensure `useToast` registers listeners only once

## Testing
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_683fedc3b564832ab8a9d5d9e506b5d9