### PR TITLE
Add SOS feature and emergency contacts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import Bookings from "./pages/hosteller/Bookings";
 import Profile from "./pages/hosteller/Profile";
 import Wishlist from "./pages/hosteller/Wishlist";
 import Filters from "./pages/hosteller/Filters";
+import SOS from "./pages/hosteller/SOS";
 
 // Owner Routes
 import OwnerLogin from "./pages/owner/OwnerLogin";
@@ -75,6 +76,7 @@ const App = () => (
           <Route path="/hosteller/wishlist" element={<Wishlist />} />
           <Route path="/hosteller/profile" element={<Profile />} />
           <Route path="/hosteller/filters" element={<Filters />} />
+          <Route path="/hosteller/sos" element={<SOS />} />
           
           {/* Owner Routes */}
           <Route path="/owner/login" element={<OwnerLogin />} />

--- a/src/pages/hosteller/Profile.tsx
+++ b/src/pages/hosteller/Profile.tsx
@@ -22,6 +22,8 @@ const Profile = () => {
     email: '', // Email might not be directly editable, but keep for display
     phone: '',
     address: '',
+    emergency_contact_name: '',
+    emergency_contact_phone: '',
     bio: '',
     profileImage: '', // URL or path to profile image
     role: 'hosteller', // Default role
@@ -84,10 +86,12 @@ const Profile = () => {
     setIsSaving(true);
     const { data, error } = await supabase
       .from("profiles")
-      .update({ 
+      .update({
         name: profile.name,
         phone: profile.phone,
         address: profile.address,
+        emergency_contact_name: profile.emergency_contact_name,
+        emergency_contact_phone: profile.emergency_contact_phone,
         bio: profile.bio,
         // email and profileImage updates would need separate handling
       })
@@ -199,10 +203,28 @@ const Profile = () => {
                   
                   <div>
                     <Label htmlFor="address">Address</Label>
-                    <Input 
+                    <Input
                       id="address"
-                      value={profile.address} 
-                      onChange={(e) => setProfile({...profile, address: e.target.value})} 
+                      value={profile.address}
+                      onChange={(e) => setProfile({...profile, address: e.target.value})}
+                    />
+                  </div>
+
+                  <div>
+                    <Label htmlFor="emergency-contact-name">Emergency Contact Name</Label>
+                    <Input
+                      id="emergency-contact-name"
+                      value={profile.emergency_contact_name}
+                      onChange={(e) => setProfile({...profile, emergency_contact_name: e.target.value})}
+                    />
+                  </div>
+
+                  <div>
+                    <Label htmlFor="emergency-contact-phone">Emergency Contact Phone</Label>
+                    <Input
+                      id="emergency-contact-phone"
+                      value={profile.emergency_contact_phone}
+                      onChange={(e) => setProfile({...profile, emergency_contact_phone: e.target.value})}
                     />
                   </div>
                   
@@ -388,13 +410,22 @@ const Profile = () => {
                   Frequently Asked Questions
                 </Button>
                 
-                <Button 
-                  variant="outline" 
+                <Button
+                  variant="outline"
                   className="w-full justify-start"
                   onClick={() => navigate("/hosteller/contact")}
                 >
                   <Phone className="h-4 w-4 mr-2" />
                   Contact Support
+                </Button>
+
+                <Button
+                  variant="destructive"
+                  className="w-full justify-start"
+                  onClick={() => navigate("/hosteller/sos")}
+                >
+                  <Bell className="h-4 w-4 mr-2" />
+                  Emergency SOS
                 </Button>
                 
                 <Button 

--- a/src/pages/hosteller/SOS.tsx
+++ b/src/pages/hosteller/SOS.tsx
@@ -1,0 +1,58 @@
+import React, { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Loader2 } from "lucide-react";
+import { toast } from "@/components/ui/sonner";
+import { supabase } from "@/lib/supabase";
+import { useNavigate } from "react-router-dom";
+
+const SOS = () => {
+  const [sending, setSending] = useState(false);
+  const [profileId, setProfileId] = useState<string | null>(null);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const loadUser = async () => {
+      const { data: user } = await supabase.auth.getUser();
+      if (user?.user) {
+        setProfileId(user.user.id);
+      }
+    };
+    loadUser();
+  }, []);
+
+  const handleSOS = async () => {
+    if (!profileId) return;
+    setSending(true);
+    const { error } = await supabase.functions.invoke("send-sos", {
+      body: { userId: profileId },
+    });
+    if (error) {
+      toast.error("Failed to send SOS: " + error.message);
+    } else {
+      toast.success("SOS alert sent to support team");
+    }
+    setSending(false);
+  };
+
+  return (
+    <div className="flex flex-col min-h-screen bg-gray-50 p-4">
+      <Card className="max-w-md w-full mx-auto mt-10">
+        <CardHeader>
+          <h1 className="text-xl font-bold">Emergency SOS</h1>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p>If you are in an emergency situation, press the button below. Our support team will be alerted immediately.</p>
+          <Button className="w-full" onClick={handleSOS} disabled={sending}>
+            {sending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}Send SOS
+          </Button>
+          <Button variant="outline" className="w-full" onClick={() => navigate(-1)}>
+            Go Back
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default SOS;

--- a/supabase/migrations/001_add_emergency_contacts.sql
+++ b/supabase/migrations/001_add_emergency_contacts.sql
@@ -1,0 +1,2 @@
+ALTER TABLE profiles ADD COLUMN emergency_contact_name text;
+ALTER TABLE profiles ADD COLUMN emergency_contact_phone text;


### PR DESCRIPTION
## Summary
- add SQL migration to extend `profiles` table
- allow hostellers to edit emergency contact fields
- provide SOS page and route
- link SOS from hosteller support menu

## Testing
- `npm run lint` *(fails: 83 problems)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68400ab9bb74832a97e8910fd8988518