### PR TITLE
Add admin profile page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,6 +41,7 @@ import Logs from "./pages/admin/Logs";
 import ComplaintManagement from "./pages/admin/ComplaintManagement";
 import SubscriptionPlans from "./pages/admin/SubscriptionPlans";
 import Notifications from "@/pages/admin/Notifications";
+import AdminProfile from "./pages/admin/AdminProfile";
 
 // Agent Routes
 import AgentLogin from "./pages/agent/AgentLogin";
@@ -272,6 +273,14 @@ const App = () => (
             element={
               <ProtectedRoute role="admin">
                 <Settings />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/admin/profile"
+            element={
+              <ProtectedRoute role="admin">
+                <AdminProfile />
               </ProtectedRoute>
             }
           />

--- a/src/components/admin/AdminLayout.tsx
+++ b/src/components/admin/AdminLayout.tsx
@@ -72,6 +72,11 @@ const AdminLayout: React.FC<AdminLayoutProps> = ({ children }) => {
       path: "/admin/logs",
     },
     {
+      title: "Profile",
+      icon: <UserCog className="h-5 w-5" />,
+      path: "/admin/profile",
+    },
+    {
       title: "Settings",
       icon: <Settings className="h-5 w-5" />,
       path: "/admin/settings",

--- a/src/pages/admin/AdminProfile.tsx
+++ b/src/pages/admin/AdminProfile.tsx
@@ -1,0 +1,76 @@
+import React, { useState } from "react";
+import AdminLayout from "@/components/admin/AdminLayout";
+import { Card, CardHeader, CardTitle, CardContent, CardFooter } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Avatar } from "@/components/ui/avatar";
+import { Camera } from "lucide-react";
+import { toast } from "@/components/ui/sonner";
+
+const AdminProfile = () => {
+  const [profile, setProfile] = useState({
+    name: "Admin User",
+    email: "admin@example.com",
+    phone: "",
+    address: "",
+  });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setProfile((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSave = () => {
+    toast.success("Profile updated successfully");
+  };
+
+  const handleImageUpload = () => {
+    document.getElementById("admin-profile-upload")?.click();
+  };
+
+  return (
+    <AdminLayout>
+      <div className="p-6 space-y-6 max-w-3xl mx-auto">
+        <h1 className="text-2xl font-bold">Admin Profile</h1>
+        <Card>
+          <CardHeader>
+            <CardTitle>Personal Information</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex items-center gap-4">
+              <Avatar className="h-20 w-20 border" />
+              <Button size="icon" onClick={handleImageUpload}>
+                <Camera className="h-4 w-4" />
+              </Button>
+              <input id="admin-profile-upload" type="file" accept="image/*" className="hidden" />
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <Label htmlFor="name">Name</Label>
+                <Input id="name" name="name" value={profile.name} onChange={handleChange} />
+              </div>
+              <div>
+                <Label htmlFor="email">Email</Label>
+                <Input id="email" name="email" type="email" value={profile.email} onChange={handleChange} />
+              </div>
+              <div>
+                <Label htmlFor="phone">Phone</Label>
+                <Input id="phone" name="phone" value={profile.phone} onChange={handleChange} />
+              </div>
+              <div>
+                <Label htmlFor="address">Address</Label>
+                <Input id="address" name="address" value={profile.address} onChange={handleChange} />
+              </div>
+            </div>
+          </CardContent>
+          <CardFooter className="justify-end">
+            <Button onClick={handleSave}>Save Changes</Button>
+          </CardFooter>
+        </Card>
+      </div>
+    </AdminLayout>
+  );
+};
+
+export default AdminProfile;


### PR DESCRIPTION
## Summary
- add `AdminProfile` page for admin info
- register `/admin/profile` route
- link profile page in admin navigation

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68404d56f204832a960b4f4a76251761