### PR TITLE
Add admin booking & owner management pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,8 @@ import ComplaintManagement from "./pages/admin/ComplaintManagement";
 import SubscriptionPlans from "./pages/admin/SubscriptionPlans";
 import Notifications from "@/pages/admin/Notifications";
 import AdminProfile from "./pages/admin/AdminProfile";
+import OwnerManagement from "./pages/admin/OwnerManagement";
+import BookingManagement from "./pages/admin/BookingManagement";
 
 // Agent Routes
 import AgentLogin from "./pages/agent/AgentLogin";
@@ -225,6 +227,22 @@ const App = () => (
             element={
               <ProtectedRoute role="admin">
                 <UserManagement />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/admin/owners"
+            element={
+              <ProtectedRoute role="admin">
+                <OwnerManagement />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/admin/bookings"
+            element={
+              <ProtectedRoute role="admin">
+                <BookingManagement />
               </ProtectedRoute>
             }
           />

--- a/src/components/admin/AdminLayout.tsx
+++ b/src/components/admin/AdminLayout.tsx
@@ -11,6 +11,8 @@ import {
   FileText, 
   Activity,
   Shield,
+  ShieldCheck,
+  Calendar,
   UserCog,
   LogOut,
   Menu,
@@ -45,6 +47,16 @@ const AdminLayout: React.FC<AdminLayoutProps> = ({ children }) => {
       title: "User & Owner Management",
       icon: <Users className="h-5 w-5" />,
       path: "/admin/users",
+    },
+    {
+      title: "Owner Management",
+      icon: <ShieldCheck className="h-5 w-5" />,
+      path: "/admin/owners",
+    },
+    {
+      title: "Booking Management",
+      icon: <Calendar className="h-5 w-5" />,
+      path: "/admin/bookings",
     },
     {
       title: "Complaints",

--- a/src/pages/admin/BookingManagement.tsx
+++ b/src/pages/admin/BookingManagement.tsx
@@ -1,0 +1,109 @@
+import React, { useState, useEffect } from "react";
+import AdminLayout from "@/components/admin/AdminLayout";
+import { Input } from "@/components/ui/input";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { Search } from "lucide-react";
+import { supabase } from "@/lib/supabase";
+import { toast } from "@/components/ui/sonner";
+
+const BookingManagement = () => {
+  const [bookings, setBookings] = useState<any[]>([]);
+  const [searchQuery, setSearchQuery] = useState("");
+
+  useEffect(() => {
+    const fetchBookings = async () => {
+      const { data, error } = await supabase
+        .from("bookings")
+        .select(
+          `id, status, check_in, check_out, profiles:hosteller_id(name, phone), hostels(name), rooms(room_number)`
+        )
+        .order("created_at", { ascending: false });
+      if (error) {
+        toast.error("Failed to load bookings");
+        return;
+      }
+      setBookings(data as any[]);
+    };
+
+    fetchBookings();
+  }, []);
+
+  const filteredBookings = bookings.filter(
+    (b) =>
+      b.profiles?.name?.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      b.id.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      b.hostels?.name?.toLowerCase().includes(searchQuery.toLowerCase())
+  );
+
+  return (
+    <AdminLayout>
+      <div className="p-6 space-y-6">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+          <h1 className="text-2xl font-bold">Booking Management</h1>
+          <div className="relative w-full sm:w-64">
+            <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
+            <Input
+              placeholder="Search bookings..."
+              className="pl-8"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+            />
+          </div>
+        </div>
+        <div className="rounded-md border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>ID</TableHead>
+                <TableHead>Hosteller</TableHead>
+                <TableHead>Hostel</TableHead>
+                <TableHead>Room</TableHead>
+                <TableHead>Check-in</TableHead>
+                <TableHead>Check-out</TableHead>
+                <TableHead>Status</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {filteredBookings.length > 0 ? (
+                filteredBookings.map((booking) => (
+                  <TableRow key={booking.id}>
+                    <TableCell className="font-medium">{booking.id}</TableCell>
+                    <TableCell>{booking.profiles?.name || "Unknown"}</TableCell>
+                    <TableCell>{booking.hostels?.name || "Unknown"}</TableCell>
+                    <TableCell>{booking.rooms?.room_number || "-"}</TableCell>
+                    <TableCell>{new Date(booking.check_in).toLocaleDateString()}</TableCell>
+                    <TableCell>{new Date(booking.check_out).toLocaleDateString()}</TableCell>
+                    <TableCell>
+                      <Badge
+                        variant={
+                          booking.status === "active"
+                            ? "default"
+                            : booking.status === "upcoming"
+                            ? "secondary"
+                            : booking.status === "completed"
+                            ? "outline"
+                            : "destructive"
+                        }
+                      >
+                        {booking.status.charAt(0).toUpperCase() + booking.status.slice(1)}
+                      </Badge>
+                    </TableCell>
+                  </TableRow>
+                ))
+              ) : (
+                <TableRow>
+                  <TableCell colSpan={7} className="text-center h-24">
+                    No bookings found
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </div>
+      </div>
+    </AdminLayout>
+  );
+};
+
+export default BookingManagement;

--- a/src/pages/admin/OwnerManagement.tsx
+++ b/src/pages/admin/OwnerManagement.tsx
@@ -1,0 +1,108 @@
+import React, { useState, useEffect } from "react";
+import AdminLayout from "@/components/admin/AdminLayout";
+import { Input } from "@/components/ui/input";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { Search } from "lucide-react";
+import { supabase } from "@/lib/supabase";
+import { toast } from "@/components/ui/sonner";
+
+const OwnerManagement = () => {
+  const [owners, setOwners] = useState<any[]>([]);
+  const [searchQuery, setSearchQuery] = useState("");
+
+  useEffect(() => {
+    const fetchOwners = async () => {
+      const { data: profiles, error } = await supabase
+        .from("profiles")
+        .select("id, name, phone, role, created_at, is_verified");
+      if (error) {
+        toast.error("Failed to load owners");
+        return;
+      }
+
+      const { data: hostels } = await supabase.from("hostels").select("owner_id");
+      const ownerHostelCounts =
+        hostels?.reduce((acc: any, h: any) => {
+          acc[h.owner_id] = (acc[h.owner_id] || 0) + 1;
+          return acc;
+        }, {}) || {};
+
+      const owners = (profiles || [])
+        .filter((u: any) => u.role === "owner")
+        .map((u: any) => ({
+          ...u,
+          joined: u.created_at,
+          hostels: ownerHostelCounts[u.id] || 0,
+          status: u.is_verified ? "active" : "blocked",
+        }));
+
+      setOwners(owners);
+    };
+
+    fetchOwners();
+  }, []);
+
+  const filteredOwners = owners.filter(
+    (owner) =>
+      owner.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      owner.phone.includes(searchQuery)
+  );
+
+  return (
+    <AdminLayout>
+      <div className="p-6 space-y-6">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+          <h1 className="text-2xl font-bold">Owner Management</h1>
+          <div className="relative w-full sm:w-64">
+            <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
+            <Input
+              placeholder="Search owners..."
+              className="pl-8"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+            />
+          </div>
+        </div>
+        <div className="rounded-md border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead>Phone</TableHead>
+                <TableHead>Hostels</TableHead>
+                <TableHead>Joined</TableHead>
+                <TableHead>Status</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {filteredOwners.length > 0 ? (
+                filteredOwners.map((owner) => (
+                  <TableRow key={owner.id}>
+                    <TableCell className="font-medium">{owner.name}</TableCell>
+                    <TableCell>{owner.phone}</TableCell>
+                    <TableCell>{owner.hostels}</TableCell>
+                    <TableCell>{new Date(owner.joined).toLocaleDateString()}</TableCell>
+                    <TableCell>
+                      <Badge variant={owner.status === "active" ? "success" : "destructive"}>
+                        {owner.status === "active" ? "Active" : "Blocked"}
+                      </Badge>
+                    </TableCell>
+                  </TableRow>
+                ))
+              ) : (
+                <TableRow>
+                  <TableCell colSpan={5} className="text-center h-24">
+                    No owners found
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </div>
+      </div>
+    </AdminLayout>
+  );
+};
+
+export default OwnerManagement;


### PR DESCRIPTION
## Summary
- create `OwnerManagement` page for admin
- add booking management page
- register routes for owners and bookings
- extend admin nav for new pages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684184ac0430832a928e69623973a2a8